### PR TITLE
Prevent phone zoom

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html>
 <head>
 <title>Ronnie Li</title>
+<!-- the following line prevents phones from zooming the page out by default -->
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="icon" type="image/png" href="favouritecon.png">
 <link href="https://fonts.googleapis.com/css?family=Open+Sans" rel="stylesheet">

--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html>
 <head>
 <title>Ronnie Li</title>
+<meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="icon" type="image/png" href="favouritecon.png">
 <link href="https://fonts.googleapis.com/css?family=Open+Sans" rel="stylesheet">
 </head>


### PR DESCRIPTION
Phones like to zoom pages out by default because they assume they aren't mobile friendly. It makes the text small and hard to read, and it's pretty dumb. This `meta` tag prevents that